### PR TITLE
Fix dupe metric name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apk add --update wget ca-certificates
 RUN wget https://github.com/prometheus-community/postgres_exporter/releases/download/v0.11.1/postgres_exporter-0.11.1.linux-amd64.tar.gz && \
   tar -zxvf /postgres_exporter-0.11.1.linux-amd64.tar.gz && \
   mv /postgres_exporter-0.11.1.linux-amd64/postgres_exporter /postgres_exporter && \
-  chmod +x /postgres_exporter
+  chmod +x /postgres_exporter && \
+  rm -Rf /postgres_exporter-0.11.1.linux-amd64*
 
 COPY queries.yaml /etc/queries.yaml
 

--- a/queries.yaml
+++ b/queries.yaml
@@ -31,7 +31,6 @@ pg_database:
   query: |
     SELECT 
       pg_database.datname, 
-      pg_database_size(pg_database.datname) as size_bytes, 
       age(datfrozenxid) as trx_frozen_id,
       pg_stat_get_db_tuples_fetched(oid) db_reads, 
       pg_stat_get_db_tuples_inserted(oid) + pg_stat_get_db_tuples_updated(oid) + pg_stat_get_db_tuples_deleted(oid) db_writes 
@@ -45,9 +44,6 @@ pg_database:
     - datname:
         usage: "LABEL"
         description: "Name of the database"
-    - size_bytes:
-        usage: "GAUGE"
-        description: "Disk space used by the database"
     - trx_frozen_id:
         usage: "GAUGE"
         description: "Age of oldest transaction ID"


### PR DESCRIPTION
Removes one of our custom metrics that was colliding with a default metric now provided in the new version of the exporter.  See https://github.com/prometheus-community/postgres_exporter/issues/706 for details